### PR TITLE
Fixed JTableInterface::store() mismatch

### DIFF
--- a/admin/tables/document.php
+++ b/admin/tables/document.php
@@ -40,7 +40,7 @@ class OsdownloadsTableDocument extends JTable
 		parent::__construct( '#__osdownloads_documents', 'id', $_db );
 	}
 
-	function store()
+	public function store($updateNulls = false);
 	{
 		if (!$this->id)
 		{


### PR DESCRIPTION
Fixes fatal error: Declaration of OsdownloadsTableDocument::store() must be compatible with that of JTableInterface::store() in administrator/components/com_osdownloads/tables/document.php on line 57 , which occurred after Joomla 3.3.0's release.
