### PR TITLE
Correction of constants for the possibility of translation

### DIFF
--- a/src/site/views/item/tmpl/default.xml
+++ b/src/site/views/item/tmpl/default.xml
@@ -25,8 +25,8 @@
 				label="COM_OSDOWNLOADS_SHOW_DOWNLOAD_COUNT"
 				class="btn-group">
 
-				<option value="0">No</option>
-				<option value="1">Yes</option>
+				<option value="0">JNO</option>
+				<option value="1">JYES</option>
 			</field>
 
 			<field name="show_category"
@@ -35,8 +35,8 @@
 				label="COM_OSDOWNLOADS_SHOW_CATEGORY"
 				class="btn-group">
 
-				<option value="0">No</option>
-				<option value="1">Yes</option>
+				<option value="0">JNO</option>
+				<option value="1">JYES</option>
 			</field>
 		</fieldset>
 	</fields>


### PR DESCRIPTION
Correction of constants for the possibility of translation.

**Menus** --> **New** --> **OSDownloads** (Select Single File), **OSDownloads Options** tab.

For example, in Russian there is no translation:

![Screenshot_1](https://user-images.githubusercontent.com/8440661/66421529-b515ec80-ea10-11e9-9329-55661eaf419f.png)

